### PR TITLE
Attempted fix for NPE when rendering jetpack

### DIFF
--- a/src/main/java/tonius/simplyjetpacks/item/ItemPack.java
+++ b/src/main/java/tonius/simplyjetpacks/item/ItemPack.java
@@ -13,6 +13,7 @@ import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
@@ -194,7 +195,7 @@ public class ItemPack<T extends PackBase> extends ItemArmor implements IControll
                 return icon;
             }
         }
-        return super.getIcon(stack, pass);
+        return Items.golden_chestplate.getIcon(stack, 0);
     }
     
     @Override


### PR DESCRIPTION
I've seen crashes (#139?) when there's a NPE which I'm pretty sure is caused by a null Icon. If the render pass is 1, it returns ItemArmor.getIconFromDamageForRenderPass (after a few calls), which returns its overlayIcon, which is null except in the case of cloth armor.

If we return some icon - even a nonsensical icon - it should at least not crash. That said, what I've done is far from optimal.